### PR TITLE
Fix special needs flags on application being lost

### DIFF
--- a/class/command/ShowFreshmenApplicationReviewCommand.php
+++ b/class/command/ShowFreshmenApplicationReviewCommand.php
@@ -12,6 +12,7 @@ class ShowFreshmenApplicationReviewCommand extends Command {
     private $roomCondition;
     private $rlcInterest;
 
+
     public function setTerm($term)
     {
         $this->term = $term;
@@ -32,21 +33,27 @@ class ShowFreshmenApplicationReviewCommand extends Command {
     public function execute(CommandContext $context)
     {
         $term = $context->get('term');
-        
+
         // If they haven't agreed, redirect to the agreement
         // TODO: actually check via docusign API
         $event = $context->get('event');
-        if(is_null($event) || !isset($event) || ($event != 'signing_complete' && $event != 'viewing_complete')){
-            
+        if(is_null($event) || !isset($event) || ($event != 'signing_complete' && $event != 'viewing_complete'))
+        {
+            if(array_key_exists('special_needs', $context->getParams()))
+            {
+              $this->saveSpecialNeeds($context);
+            }
+
             $returnCmd = CommandFactory::getCommand('ShowFreshmenApplicationReview');
             $returnCmd->setTerm($term);
-            
+
             $agreementCmd = CommandFactory::getCommand('ShowTermsAgreement');
             $agreementCmd->setTerm($term);
             $agreementCmd->setAgreedCommand($returnCmd);
             $agreementCmd->redirect();
         }
-        
+
+
         $student = StudentFactory::getStudentByUsername(UserStatus::getUsername(), $term);
 
         $errorCmd = CommandFactory::getCommand('ShowHousingApplicationForm');
@@ -69,16 +76,39 @@ class ShowFreshmenApplicationReviewCommand extends Command {
         }
 
         try{
+
             $application = HousingApplicationFactory::getApplicationFromSession($_SESSION['application_data'], $term, $student, $appType);
         }catch(Exception $e){
             NQ::simple('hms', hms\NotificationView::ERROR, $e->getMessage());
             $errorCmd->redirect();
         }
-        
+
+
         PHPWS_Core::initModClass('hms', 'FreshmenApplicationReview.php');
         $view = new FreshmenApplicationReview($student, $term, $application);
         $context->setContent($view->show());
     }
+
+    public function saveSpecialNeeds(CommandContext $context)
+    {
+      if(array_key_exists('physical_disability', $context->get('special_needs')))
+      {
+        $_SESSION['application_data']['special_needs']['physical_disability'] = 'physical_disability';
+      }
+      if(array_key_exists('psych_disability', $context->get('special_needs')))
+      {
+        $_SESSION['application_data']['special_needs']['psych_disability'] = 'psych_disability';
+      }
+      if(array_key_exists('medical_need', $context->get('special_needs')))
+      {
+        $_SESSION['application_data']['special_needs']['medical_need'] = 'medical_need';
+      }
+      if(array_key_exists('gender_need', $context->get('special_needs')))
+      {
+        $_SESSION['application_data']['special_needs']['gender_need'] = 'gender_need';
+      }
+    }
+
 }
 
 ?>


### PR DESCRIPTION
The special needs values were never being saved before a context switch to the terms agreement, they are now being saved in the application session variable. Refs #981 