### PR TITLE
Add lottery invite expiration time to activity log note

### DIFF
--- a/class/LotteryProcess.php
+++ b/class/LotteryProcess.php
@@ -207,7 +207,7 @@ class LotteryProcess {
         HMS_Email::send_lottery_invite($student->getUsername(), $student->getName(), $this->academicYear);
 
         // Log that the invite was sent
-        HMS_Activity_Log::log_activity($student->getUsername(), ACTIVITY_LOTTERY_INVITED, UserStatus::getUsername());
+        HMS_Activity_Log::log_activity($student->getUsername(), ACTIVITY_LOTTERY_INVITED, UserStatus::getUsername(), "Expires on " . date('m/d/Y h:i:s a', $this->expireTime));
     }
 
     private function sendWinningReminderEmails()
@@ -713,5 +713,3 @@ class LotteryProcess {
         return $remainingApplications;
     }
 }
-
-


### PR DESCRIPTION
Added a note which when a lottery invitation is sent the time it expires at is included in the note, which will show up on the student's log. Refs #895 