### PR TITLE
Student Cancel Room Change Request

### DIFF
--- a/class/RoomChangeMenuBlockView.php
+++ b/class/RoomChangeMenuBlockView.php
@@ -42,40 +42,33 @@ class RoomChangeMenuBlockView extends hms\View {
             $participant = RoomChangeParticipantFactory::getParticipantByRequestStudent($this->changeRequest, $this->student);
             $state = $participant->getState();
 
-            // If this student needs to approve their part of this request
+            // If this student needs to approve their part of this request, show link to view request
             if($state instanceof ParticipantStateNew) {
                 $approvalCmd = CommandFactory::getCommand('ShowRoomChangeRequestApproval');
                 $tpl['APPROVAL_CMD'] = $approvalCmd->getLink('View the request');
-            }
-            else
-            {
-                if($state instanceof ParticipantStateStudentApproved)
-                {
+            } else {
+                // Otherwise, if this student has approved
+                if($state instanceof ParticipantStateStudentApproved) {
+
+                    // Check whether everyone else has approved it
                     $participantList = RoomChangeParticipantFactory::getParticipantsByRequest($this->changeRequest);
                     $allApproved     = true;
-
-
-                    foreach($participantList as $rcParticipant)
-                    {
-                        if($rcParticipant->state_name == 'New')
-                        {
+                    foreach($participantList as $rcParticipant) {
+                        if($rcParticipant->state_name == 'New') {
                             $allApproved = false;
                         }
                     }
 
                     // If not all the participants have approved then give the participants that have approved a
                     // link to cancel the request, but if all have approved they can no longer cancel via student menu.
-                    if(!$allApproved)
-                    {
-                        $cancelCmd     = CommandFactory::getCommand('StudentRoomChangeCancel');
+                    if(!$allApproved) {
+                        $cancelCmd     = CommandFactory::getCommand('RoomChangeStudentCancel');
                         $tpl['CANCEL'] = $cancelCmd->getUri() . '&requestId=' . $this->changeRequest->getId();
-                    }
-                    else {
+                    } else {
                         // Request is pending, but this student doesn't need to do anything
                         $tpl['PENDING'] = "";
                     }
-                }
-                else {
+                } else {
                     // Request is pending, but this student doesn't need to do anything
                     $tpl['PENDING'] = "";
                 }

--- a/class/RoomChangeMenuBlockView.php
+++ b/class/RoomChangeMenuBlockView.php
@@ -46,10 +46,39 @@ class RoomChangeMenuBlockView extends hms\View {
             if($state instanceof ParticipantStateNew) {
                 $approvalCmd = CommandFactory::getCommand('ShowRoomChangeRequestApproval');
                 $tpl['APPROVAL_CMD'] = $approvalCmd->getLink('View the request');
-            } else {
-                // Request if pending, but this student doesn't need to do anything
-            $tpl['PENDING'] = "";
+            }
+            else
+            {
+                if($state instanceof ParticipantStateStudentApproved)
+                {
+                    $participantList = RoomChangeParticipantFactory::getParticipantsByRequest($this->changeRequest);
+                    $allApproved     = true;
 
+
+                    foreach($participantList as $rcParticipant)
+                    {
+                        if($rcParticipant->state_name == 'New')
+                        {
+                            $allApproved = false;
+                        }
+                    }
+
+                    // If not all the participants have approved then give the participants that have approved a
+                    // link to cancel the request, but if all have approved they can no longer cancel via student menu.
+                    if(!$allApproved)
+                    {
+                        $cancelCmd     = CommandFactory::getCommand('StudentRoomChangeCancel');
+                        $tpl['CANCEL'] = $cancelCmd->getUri() . '&requestId=' . $this->changeRequest->getId();
+                    }
+                    else {
+                        // Request is pending, but this student doesn't need to do anything
+                        $tpl['PENDING'] = "";
+                    }
+                }
+                else {
+                    // Request is pending, but this student doesn't need to do anything
+                    $tpl['PENDING'] = "";
+                }
             }
             $tpl['ICON'] = FEATURE_OPEN_ICON;
         } else {

--- a/class/command/RoomChangeStudentCancelCommand.php
+++ b/class/command/RoomChangeStudentCancelCommand.php
@@ -1,18 +1,19 @@
 <?php
 
 PHPWS_Core::initModClass('hms', 'RoomChangeRequestFactory.php');
+PHPWS_Core::initModClass('hms', 'HMS_Email.php');
+PHPWS_Core::initModClass('hms', 'StudentFactory.php');
 
-class StudentRoomChangeCancelCommand extends Command {
+class RoomChangeStudentCancelCommand extends Command {
 
     public function getRequestVars()
     {
-        return array('action'=>'StudentRoomChangeCancel');
+        return array('action'=>'RoomChangeStudentCancel');
     }
 
     public function execute(CommandContext $context)
     {
         $requestId = $context->get('requestId');
-        $reason = "Room change cancelled by student via menu.";
 
         // Load the request
         $request = RoomChangeRequestFactory::getRequestById($requestId);
@@ -21,20 +22,19 @@ class StudentRoomChangeCancelCommand extends Command {
         $cmd = CommandFactory::getCommand('ShowReturningStudentMenu');
 
         // Set the denied reason
-        $request->setDeniedReasonPublic($reason);
+        $request->setDeniedReasonPublic("Room change cancelled by student via menu.");
         $request->save();
 
         // Transition request to cancelled status
         $request->transitionTo(new RoomChangeStateCancelled($request, time(), null, UserStatus::getUsername()));
 
         // Transition all participants to cancelled
-        // TODO... Do this in the cancelled transition?
         $participants = $request->getParticipants();
 
         foreach ($participants as $p) {
             $p->transitionTo(new ParticipantStateCancelled($p, time(), null, UserStatus::getUsername()));
 
-            //Release the bed reservation, if any
+            // Release the bed reservation, if any
             $bedId = $p->getToBed();
             if ($bedId != null) {
                 $bed = new HMS_Bed($bedId);
@@ -45,12 +45,10 @@ class StudentRoomChangeCancelCommand extends Command {
 
         // Notify everyone involved
         try {
-            PHPWS_Core::initModClass('hms', 'StudentFactory.php');
             $student = StudentFactory::getStudentByUsername(UserStatus::getUsername(), $request->getTerm());
         } catch(StudentNotFoundException $e) {
             $student = null;
         }
-        PHPWS_Core::initModClass('hms', 'HMS_Email.php');
         HMS_Email::sendRoomChangeCancelledNotice($request, $student);
 
         $cmd->redirect();

--- a/class/command/ShowRoomChangeRequestApprovalCommand.php
+++ b/class/command/ShowRoomChangeRequestApprovalCommand.php
@@ -8,13 +8,13 @@
  * @package homestead
  */
 class ShowRoomChangeRequestApprovalCommand extends Command {
-    
+
     public function getRequestVars()
     {
         return array('action' => 'ShowRoomChangeRequestApproval');
     }
 
-    public function execute(CommandContext $context) 
+    public function execute(CommandContext $context)
     {
         PHPWS_Core::initModClass('hms', 'StudentFactory.php');
         PHPWS_Core::initModClass('hms', 'RoomChangeRequestFactory.php');
@@ -41,5 +41,3 @@ class ShowRoomChangeRequestApprovalCommand extends Command {
         $context->setContent($view->show());
     }
 }
-
-

--- a/class/command/StudentRoomChangeCancelCommand.php
+++ b/class/command/StudentRoomChangeCancelCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+PHPWS_Core::initModClass('hms', 'RoomChangeRequestFactory.php');
+
+class StudentRoomChangeCancelCommand extends Command {
+
+    public function getRequestVars()
+    {
+        return array('action'=>'StudentRoomChangeCancel');
+    }
+
+    public function execute(CommandContext $context)
+    {
+        $requestId = $context->get('requestId');
+        $reason = "Room change cancelled by student via menu.";
+
+        // Load the request
+        $request = RoomChangeRequestFactory::getRequestById($requestId);
+
+        // Command for redirecting back to the request view on success or error
+        $cmd = CommandFactory::getCommand('ShowReturningStudentMenu');
+
+        // Set the denied reason
+        $request->setDeniedReasonPublic($reason);
+        $request->save();
+
+        // Transition request to cancelled status
+        $request->transitionTo(new RoomChangeStateCancelled($request, time(), null, UserStatus::getUsername()));
+
+        // Transition all participants to cancelled
+        // TODO... Do this in the cancelled transition?
+        $participants = $request->getParticipants();
+
+        foreach ($participants as $p) {
+            $p->transitionTo(new ParticipantStateCancelled($p, time(), null, UserStatus::getUsername()));
+
+            //Release the bed reservation, if any
+            $bedId = $p->getToBed();
+            if ($bedId != null) {
+                $bed = new HMS_Bed($bedId);
+                $bed->clearRoomChangeReserved();
+                $bed->save();
+            }
+        }
+
+        // Notify everyone involved
+        try {
+            PHPWS_Core::initModClass('hms', 'StudentFactory.php');
+            $student = StudentFactory::getStudentByUsername(UserStatus::getUsername(), $request->getTerm());
+        } catch(StudentNotFoundException $e) {
+            $student = null;
+        }
+        PHPWS_Core::initModClass('hms', 'HMS_Email.php');
+        HMS_Email::sendRoomChangeCancelledNotice($request, $student);
+
+        $cmd->redirect();
+    }
+}

--- a/templates/student/menuBlocks/roomChangeMenuBlock.tpl
+++ b/templates/student/menuBlocks/roomChangeMenuBlock.tpl
@@ -20,6 +20,10 @@ It's too late to request a room change. The deadline passed on {END_DEADLINE}.
 Your room change request has been submitted. Once it is approved, you will be notified via an email to your ASU email account. {PENDING}
 <!-- END pending -->
 
+<!-- BEGIN cancel -->
+Your room change request has been submitted. It is currently waiting on another participant to approve the change. You may still <a href="{CANCEL}">cancel this request.</a>
+<!-- END cancel -->
+
 <!-- BEGIN approval -->
 You have a room change request that needs your approval. {APPROVAL_CMD}
 <!-- END approval -->


### PR DESCRIPTION
Added the ability for a student who has requested to switch with some one to cancel as long as the other student has not yet confirmed the swap.

Cherry-picked from #1117  Possibly fixed #817 
