### PR TITLE
Parent email verification using 3rd-party API

### DIFF
--- a/class/EmergencyContactFormView.php
+++ b/class/EmergencyContactFormView.php
@@ -26,7 +26,7 @@ class EmergencyContactFormView extends hms\View {
         $submitCmd->initForm($form);
 
         javascript('jquery');
-        javascript('modules/hms/EmailValidation');
+        javascriptMod('hms', 'EmailValidation');
 
         $tpl = array();
 

--- a/class/EmergencyContactFormView.php
+++ b/class/EmergencyContactFormView.php
@@ -25,6 +25,9 @@ class EmergencyContactFormView extends hms\View {
         $submitCmd->setTerm($this->term);
         $submitCmd->initForm($form);
 
+        javascript('jquery');
+        javascript('modules/hms/EmailValidation');
+
         $tpl = array();
 
         /****************

--- a/class/HousingApplicationFormView.php
+++ b/class/HousingApplicationFormView.php
@@ -25,6 +25,9 @@ class HousingApplicationFormView extends hms\View
 
         $submitCmd->initForm($form);
 
+        javascript('jquery');
+        javascript('modules/hms/EmailValidation');
+
         $tpl = array();
 
         /****************

--- a/class/HousingApplicationFormView.php
+++ b/class/HousingApplicationFormView.php
@@ -26,7 +26,7 @@ class HousingApplicationFormView extends hms\View
         $submitCmd->initForm($form);
 
         javascript('jquery');
-        javascript('modules/hms/EmailValidation');
+        javascriptMod('hms', 'EmailValidation');
 
         $tpl = array();
 

--- a/javascript/EmailValidation/EmailValidation.js
+++ b/javascript/EmailValidation/EmailValidation.js
@@ -1,0 +1,82 @@
+// document ready
+$(function() {
+
+  // capture all enter and do nothing
+  $('#phpws_form_emergency_contact_email').keypress(function(e) {
+    if(e.which == 13) {
+      $('#phpws_form_emergency_contact_email').trigger('focusout');
+      return false;
+    }
+  });
+
+  // attach jquery plugin to validate address
+  $('#phpws_form_emergency_contact_email').mailgun_validator({
+    api_key: 'pubkey-d296f8e565badf7cd16c0e19dc0041e9', // replace this with your Mailgun public API key
+    in_progress: contact_validation_in_progress,
+    success: contact_validation_success,
+    error: contact_validation_error,
+  });
+
+  // capture all enter and do nothing
+  $('#phpws_form_missing_person_email').keypress(function(e) {
+    if(e.which == 13) {
+      $('#phpws_form_missing_person_email').trigger('focusout');
+      return false;
+    }
+  });
+
+  // attach jquery plugin to validate address
+  $('#phpws_form_missing_person_email').mailgun_validator({
+    api_key: 'pubkey-d296f8e565badf7cd16c0e19dc0041e9', // replace this with your Mailgun public API key
+    in_progress: missing_validation_in_progress,
+    success: missing_validation_success,
+    error: missing_validation_error,
+  });
+
+});
+
+// while the lookup is performing
+function contact_validation_in_progress() {
+  $('#contact_status').html("");
+}
+
+// if email successfull validated
+function contact_validation_success(data) {
+  $('#contact_status').html(get_suggestion_str(data['is_valid'], data['did_you_mean']));
+}
+
+// if email is invalid
+function contact_validation_error(error_message) {
+  $('#contact_status').html(error_message);
+}
+
+// while the lookup is performing
+function missing_validation_in_progress() {
+  $('#missing_status').html("");
+}
+
+// if email successfull validated
+function missing_validation_success(data) {
+  $('#missing_status').html(get_suggestion_str(data['is_valid'], data['did_you_mean']));
+}
+
+// if email is invalid
+function missing_validation_error(error_message) {
+  $('#missing_status').html(error_message);
+}
+
+
+
+// suggest a valid email
+function get_suggestion_str(is_valid, alternate) {
+  if (is_valid) {
+    if (alternate) {
+      result += '<p class="text-warning"> (Though did you mean <em>' + alternate + '</em>?)</p>';
+    }
+    return result
+  } else if (alternate) {
+    return '<p class="text-warning">Did you mean <em>' +  alternate + '</em>?</p>';
+  } else {
+    return '<p class="text-danger">Address is invalid.</p>';
+  }
+}

--- a/javascript/EmailValidation/EmailValidation.js
+++ b/javascript/EmailValidation/EmailValidation.js
@@ -69,14 +69,12 @@ function missing_validation_error(error_message) {
 
 // suggest a valid email
 function get_suggestion_str(is_valid, alternate) {
-  if (is_valid) {
-    if (alternate) {
-      result += '<p class="text-warning"> (Though did you mean <em>' + alternate + '</em>?)</p>';
-    }
-    return result
-  } else if (alternate) {
+
+  if (alternate) {
     return '<p class="text-warning">Did you mean <em>' +  alternate + '</em>?</p>';
-  } else {
+  } else if (!is_valid){
     return '<p class="text-danger">Address is invalid.</p>';
+  } else {
+    return '';
   }
 }

--- a/javascript/EmailValidation/head.js
+++ b/javascript/EmailValidation/head.js
@@ -1,2 +1,2 @@
-<script type="text/javascript" src="mod/hms/javascript/EmailValidation/validator/mailgun_validator.js"></script>
+<script type="text/javascript" src="mod/hms/javascript/EmailValidation/mailgun_validator.js"></script>
 <script type="text/javascript" src="mod/hms/javascript/EmailValidation/EmailValidation.js"></script>

--- a/javascript/EmailValidation/head.js
+++ b/javascript/EmailValidation/head.js
@@ -1,0 +1,2 @@
+<script type="text/javascript" src="mod/hms/javascript/EmailValidation/validator/mailgun_validator.js"></script>
+<script type="text/javascript" src="mod/hms/javascript/EmailValidation/EmailValidation.js"></script>

--- a/javascript/EmailValidation/mailgun_validator.js
+++ b/javascript/EmailValidation/mailgun_validator.js
@@ -1,0 +1,144 @@
+//
+// Mailgun Address Validation Plugin
+//
+// Attaching to a form:
+//
+//    $('jquery_selector').mailgun_validator({
+//        api_key: 'api-key',
+//        in_progress: in_progress_callback, // called when request is made to validator
+//        success: success_callback,         // called when validator has returned
+//        error: validation_error,           // called when an error reaching the validator has occured
+//    });
+//
+//
+// Sample JSON in success callback:
+//
+//  {
+//      "is_valid": true,
+//      "parts": {
+//          "local_part": "john.smith@example.com",
+//          "domain": "example.com",
+//          "display_name": ""
+//      },
+//      "address": "john.smith@example.com",
+//      "did_you_mean": null
+//  }
+//
+// More API details: https://api.mailgun.net/v2/address
+//
+
+(function( $ ) {
+    $.fn.mailgun_validator = function(options) {
+        return this.each(function() {
+            var thisElement = $(this);
+            thisElement.focusout(function(e) {
+                //Trim string and autocorrect whitespace issues
+                var elementValue = thisElement.val();
+                elementValue = $.trim(elementValue);
+                thisElement.val(elementValue);
+
+                //Attach event to options
+                options.e = e;
+
+                run_validator(elementValue, options, thisElement);
+            });
+        });
+    };
+
+    function run_validator(address_text, options, element) {
+        //Abort existing AJAX Request to prevent flooding
+        if(element.mailgunRequest) {
+            element.mailgunRequest.abort();
+            element.mailgunRequest = null;
+        }
+
+        // don't run validator without input
+        if (!address_text) {
+            return;
+        }
+
+        // validator is in progress
+        if (options && options.in_progress) {
+            options.in_progress(options.e);
+        }
+
+        // don't run dupicate calls
+        if (element.mailgunLastSuccessReturn) {
+            if (address_text == element.mailgunLastSuccessReturn.address) {
+                if (options && options.success) {
+                    options.success(element.mailgunLastSuccessReturn, options.e);
+                }
+                return;
+            }
+        }
+
+        // length and @ syntax check
+        var error_message = false;
+        if (address_text.length > 512)
+            error_message = 'Email address exceeds maxiumum allowable length of 512.';
+        else if (1 !== address_text.split('@').length-1)
+            error_message = 'Email address must contain only one @.';
+
+        if (error_message) {
+            if (options && options.error) {
+                options.error(error_message, options.e);
+            }
+            else {
+                if (console) console.log(error_message);
+            }
+            return;
+        }
+
+        // require api key
+        if (options && options.api_key == undefined) {
+            if (console) console.log('Please pass in api_key to mailgun_validator.');
+        }
+
+        // timeout incase of some kind of internal server error
+        var timeoutID = setTimeout(function() {
+            error_message = 'Error occurred, unable to validate address.';
+            if (!success) {
+                //Abort existing AJAX Request for a true timeout
+                if(element.mailgunRequest) {
+                    element.mailgunRequest.abort();
+                    element.mailgunRequest = null;
+                }
+
+                if (options && options.error) {
+                    options.error(error_message, options.e);
+                }
+                else {
+                    if (console) console.log(error_message);
+                }
+            }
+        }, 30000); //30 seconds
+
+        // make ajax call to get validation results
+        element.mailgunRequest = $.ajax({
+            type: "GET",
+            url: 'https://api.mailgun.net/v2/address/validate?callback=?',
+            data: { address: address_text, api_key: options.api_key },
+            dataType: "jsonp",
+            crossDomain: true,
+            success: function(data, status_text) {
+                clearTimeout(timeoutID);
+
+                element.mailgunLastSuccessReturn = data;
+                if (options && options.success) {
+                    options.success(data, options.e);
+                }
+            },
+            error: function(request, status_text, error) {
+                clearTimeout(timeoutID);
+                error_message = 'Error occurred, unable to validate address.';
+
+                if (options && options.error) {
+                    options.error(error_message, options.e);
+                }
+                else {
+                    if (console) console.log(error_message);
+                }
+            }
+        });
+    }
+})( jQuery );

--- a/templates/student/emergency_contact_form.tpl
+++ b/templates/student/emergency_contact_form.tpl
@@ -66,6 +66,8 @@
     </label>
     <div class="col-md-3 col-md-offset-2">
       {EMERGENCY_CONTACT_EMAIL}
+      <div id="contact_status">
+      </div>
     </div>
   </div>
 
@@ -132,6 +134,8 @@
     </label>
     <div class="col-md-3 col-md-offset-3">
       {MISSING_PERSON_EMAIL}
+      <div id="missing_status">
+      </div>
     </div>
   </div>
 

--- a/templates/student/student_application.tpl
+++ b/templates/student/student_application.tpl
@@ -171,6 +171,8 @@
             <div class="row">
                 <div class="col-md-4">
                     {EMERGENCY_CONTACT_EMAIL}
+                    <div id="contact_status">
+                    </div>
                 </div>
             </div>
         </div>
@@ -230,6 +232,8 @@
             <div class="row">
                 <div class="col-md-4">
                     {MISSING_PERSON_EMAIL}
+                    <div id="missing_status">
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Refs #973 

Needs more work before we can merge this:

- [ ] Use verification on the parent/guardian emergency contact field (on the housing application and contact update page), which is the one we're really interested in (currently it works only on the missing person field)
- [ ] Remove duplicate code chunks in EmailValidation.js
- [ ] Show a spinner next to the field with the word "Checking..." while verification is in progress (it's slow sometimes).
- [ ] Allow the user to click the "Did you mean...?" suggestions to auto-substitute the suggestion into the field
- [ ] Disable form submission if any of the email addresses are invalid
- [ ] Use React?
- [ ] Put the API key into a setting, so it's not hard-coded into the repo.