### PR TITLE
Fixed the issues with the timepicker (jQuery) not working properly  

### DIFF
--- a/javascript/studentSearch/default.php
+++ b/javascript/studentSearch/default.php
@@ -6,5 +6,5 @@
  */
 
 $studentSearch = PHPWS_SOURCE_HTTP . 'mod/hms/javascript/studentSearch/script.js';
-\Layout::addJSHeader('<script type="text/javascript" src="' . PHPWS_SOURCE_HTTP . 'mod/hms/bower_components/typeahead.js/dist/typeahead.bundle.js"></script>');
+\Layout::addJSHeader('<script type="text/javascript" src="' . PHPWS_SOURCE_HTTP . 'mod/hms/node_modules/corejs-typeahead/dist/typeahead.bundle.js"></script>');
 \Layout::addJSHeader("<script type='text/javascript' src='$studentSearch'></script>");

--- a/javascript/timePicker/jquery.timePicker.js
+++ b/javascript/timePicker/jquery.timePicker.js
@@ -18,6 +18,45 @@
  *   show24Hours: use a 24-hour scheme
  */
 
+/*
+The code below is the $.browser intitalization, since the .browser method was removed in the newest jquery update
+*/
+ var matched, browser;
+
+ jQuery.uaMatch = function( ua ) {
+     ua = ua.toLowerCase();
+
+     var match = /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
+         /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
+         /(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
+         /(msie) ([\w.]+)/.exec( ua ) ||
+         ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec( ua ) ||
+         [];
+
+     return {
+         browser: match[ 1 ] || "",
+         version: match[ 2 ] || "0"
+     };
+ };
+
+ matched = jQuery.uaMatch( navigator.userAgent );
+ browser = {};
+
+ if ( matched.browser ) {
+     browser[ matched.browser ] = true;
+     browser.version = matched.version;
+ }
+
+ // Chrome is Webkit, but Webkit is also Safari.
+ if ( browser.chrome ) {
+     browser.webkit = true;
+ } else if ( browser.webkit ) {
+     browser.safari = true;
+ }
+
+ jQuery.browser = browser;
+
+
 (function($){
   $.fn.timePicker = function(options) {
     // Build main options before element iteration

--- a/javascript/timePicker/timePicker.css
+++ b/javascript/timePicker/timePicker.css
@@ -19,7 +19,7 @@ div.time-picker ul {
 }
 div.time-picker li {
   cursor: pointer;
-  height: 10px;
+  height: 20px;
   font: 12px/1 Helvetica, Arial, sans-serif;
   padding: 4px 3px;
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "chartist": "^0.11.0",
     "corejs-typeahead": "^1.1.1",
-    "flot": "^0.8.0-alpha"
+    "flot": "^0.8.0-alpha",
+    "react-data-grid-addons": "^2.0.73"
   },
   "devDependencies": {
     "assets-webpack-plugin": "^3.4.0",


### PR DESCRIPTION
So, JQuery removed the $.browser method in 1.9 which I added onto to the timepicker file that used it. I'm not sure if that's the best idea; I feel that it would have been better to make a js file/class that would return the browser, so if other files use it we can reuse the code. 

Also, I think we talked about using a Bootstrap modal instead of a JQuery one. I can work on this if needed. 